### PR TITLE
Endpoint registered, web front port added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ go.work.sum
 *.old
 tmp/
 *.tmp
-
+.vscode/
+.idea/
 # project confi
 ePrometna.json

--- a/controller/loginController.go
+++ b/controller/loginController.go
@@ -40,7 +40,9 @@ func (c *LoginController) RegisterEndpoints(api *gin.RouterGroup) {
 	// register Endpoints
 	group.POST("/login", c.login)
 	group.POST("/refresh", c.RefreshToken)
-	group.OPTIONS("/login", c.login)
+	group.OPTIONS("/login", func(c *gin.Context) {
+	    c.Status(http.StatusNoContent)
+	})
 }
 
 // Login godoc

--- a/controller/loginController.go
+++ b/controller/loginController.go
@@ -40,6 +40,7 @@ func (c *LoginController) RegisterEndpoints(api *gin.RouterGroup) {
 	// register Endpoints
 	group.POST("/login", c.login)
 	group.POST("/refresh", c.RefreshToken)
+	group.OPTIONS("/login", c.login)
 }
 
 // Login godoc

--- a/httpServer/middleware.go
+++ b/httpServer/middleware.go
@@ -65,9 +65,9 @@ func Protect(roles ...model.UserRole) gin.HandlerFunc {
 func corsHeader() gin.HandlerFunc {
 	// Define allowed origins
 	allowedOrigins := map[string]bool{
-		"http://localhost:8090": true,
-		"http://localhost:8080": true,
+		"http://localhost:3000": true,
 		"http://localhost:8081": true,
+		"http://localhost:8082": true,
 	}
 
 	return func(c *gin.Context) {


### PR DESCRIPTION
Added group.OPTIONS("/login", c.login) in RegisterEndpoints.

port 3000 defined in allowedOrigins